### PR TITLE
yT can be <y0

### DIFF
--- a/R/AUDPC_2_points.R
+++ b/R/AUDPC_2_points.R
@@ -11,8 +11,8 @@ AUDPC_2_points <- function(time, y0, yT) {
   if (!all(is.numeric(time), is.numeric(y0), is.numeric(yT))) {
     stop("All values must be numeric")
   }
-  if ((y0 < 0 || y0 >= 1 || yT >= 1)) {
-    stop("y0 and yT must be between 0 and <1")
+  if ((y0 < 0 || y0 > 1 || yT > 1) || (y0 == yT)) {
+    stop("y0 and yT must be between 0 and <=1 and must not be equal.")
   }
   # eqn. 3 from Jeger and Viljanen-Rollinson (2001), rate parameter r
   r <- (log(yT / (1 - yT)) - log(y0 / (1 - y0))) / time

--- a/R/AUDPC_2_points.R
+++ b/R/AUDPC_2_points.R
@@ -11,8 +11,8 @@ AUDPC_2_points <- function(time, y0, yT) {
   if (!all(is.numeric(time), is.numeric(y0), is.numeric(yT))) {
     stop("All values must be numeric")
   }
-  if ((y0 < 0 || y0 >= 1) || (yT < y0 || yT >= 1)) {
-    stop("y0 and yT must be between 0 and <1 and yT must be > y0")
+  if ((y0 < 0 || y0 >= 1 || yT >= 1)) {
+    stop("y0 and yT must be between 0 and <1")
   }
   # eqn. 3 from Jeger and Viljanen-Rollinson (2001), rate parameter r
   r <- (log(yT / (1 - yT)) - log(y0 / (1 - y0))) / time

--- a/R/AUDPC_2_points.R
+++ b/R/AUDPC_2_points.R
@@ -1,21 +1,37 @@
-AUDPC_2_points <- function(time, y0, yT) {
-  if (missing(time)) {
-    stop("Missing 'time' value")
+AUDPC_2_points = function(time, y0, yT) {
+  # Input existence checks
+  if (missing(time) || missing(y0) || missing(yT)) {
+    stop("All parameters (time, y0, yT) are required", call. = FALSE)
   }
-  if (missing(y0)) {
-    stop("Missing 'y0' value")
+
+  # Combined type and length validation
+  if (
+    !is.numeric(time) ||
+      !is.numeric(y0) ||
+      !is.numeric(yT) ||
+      length(time) != 1 ||
+      length(y0) != 1 ||
+      length(yT) != 1
+  ) {
+    stop("All inputs must be numeric scalar values (length 1)", call. = FALSE)
   }
-  if (missing(yT)) {
-    stop("Missing 'yT' value")
+
+  # Combined finite checks
+  if (anyNA(c(time, y0, yT)) || !all(is.finite(c(time, y0, yT)))) {
+    stop("All values must be finite (not NA, NaN, or Inf)", call. = FALSE)
   }
-  if (!all(is.numeric(time), is.numeric(y0), is.numeric(yT))) {
-    stop("All values must be numeric")
+
+  # Combined range validation
+  if (y0 <= 0 || y0 >= 1 || yT <= 0 || yT >= 1 || y0 == yT || time <= 0) {
+    stop(
+      "y0 and yT must be strictly between 0 and 1 (exclusive), ",
+      "must not be equal, and time must be positive",
+      call. = FALSE
+    )
   }
-  if ((y0 < 0 || y0 > 1 || yT > 1) || (y0 == yT)) {
-    stop("y0 and yT must be between 0 and <=1 and must not be equal.")
-  }
+
   # eqn. 3 from Jeger and Viljanen-Rollinson (2001), rate parameter r
-  r <- (log(yT / (1 - yT)) - log(y0 / (1 - y0))) / time
+  r = (log(yT / (1 - yT)) - log(y0 / (1 - y0))) / time
 
   # eqn. 2 from Jeger and Viljanen-Rollinson (2001), AUDPC estimation
   return(time + log(y0 / yT) / r)

--- a/man/AUDPC_2_points.Rd
+++ b/man/AUDPC_2_points.Rd
@@ -12,7 +12,7 @@ assessment.}
 intensity measurement. Must be greater than zero and less than one.}
 
 \item{yT}{A numeric value representing the disease intensity at the last
-intensity measurement. Must be greater than \code{y0} and less than one.}
+intensity measurement. Must be greater than zero and less than one.}
 }
 \description{
 Estimates area under the disease progress curve \acronym{AUDPC} from two

--- a/tests/testthat/test-AUDCP_2_points.R
+++ b/tests/testthat/test-AUDCP_2_points.R
@@ -13,28 +13,28 @@ test_that("AUDCP_2_points errors with missing `yT`", {
 test_that("AUDCP_2_points errors when y0 < 0", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = -0.1, yT = 0.9),
-    "y0 and yT must be between 0 and <=1 and yT must not be equal"
+    "y0 and yT must be between 0 and <=1 and must not be equal"
   )
 })
 
 test_that("AUDCP_2_points errors when y0 > 1", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 1.1, yT = 0.9),
-    "y0 and yT must be between 0 and <=1 and yT must not be equal"
+    "y0 and yT must be between 0 and <=1 and must not be equal"
   )
 })
 
 test_that("AUDCP_2_points errors when yT > 1", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 0.1, yT = 1.1),
-    "y0 and yT must be between 0 and <=1 and yT must not be equal"
+    "y0 and yT must be between 0 and <=1 and must not be equal"
   )
 })
 
 test_that("AUDCP_2_points errors when y0 == yT", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 0.1, yT = 0.1),
-    "y0 and yT must be between 0 and <=1 and yT must not be equal."
+    "y0 and yT must be between 0 and <=1 and must not be equal."
   )
 })
 

--- a/tests/testthat/test-AUDCP_2_points.R
+++ b/tests/testthat/test-AUDCP_2_points.R
@@ -13,14 +13,28 @@ test_that("AUDCP_2_points errors with missing `yT`", {
 test_that("AUDCP_2_points errors when y0 < 0", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = -0.1, yT = 0.9),
-    "y0 and yT must be between 0 and <1 and yT must be > y0"
+    "y0 and yT must be between 0 and <=1 and yT must not be equal"
   )
 })
 
-test_that("AUDCP_2_points errors when y0 >= 1", {
+test_that("AUDCP_2_points errors when y0 > 1", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 1.1, yT = 0.9),
-    "y0 and yT must be between 0 and <1 and yT must be > y0"
+    "y0 and yT must be between 0 and <=1 and yT must not be equal"
+  )
+})
+
+test_that("AUDCP_2_points errors when yT > 1", {
+  expect_error(
+    AUDPC_2_points(time = 10, y0 = 0.1, yT = 1.1),
+    "y0 and yT must be between 0 and <=1 and yT must not be equal"
+  )
+})
+
+test_that("AUDCP_2_points errors when y0 == yT", {
+  expect_error(
+    AUDPC_2_points(time = 10, y0 = 0.1, yT = 0.1),
+    "y0 and yT must be between 0 and <=1 and yT must not be equal."
   )
 })
 

--- a/tests/testthat/test-AUDCP_2_points.R
+++ b/tests/testthat/test-AUDCP_2_points.R
@@ -1,40 +1,88 @@
-test_that("AUDCP_2_points errors with missing `time`", {
-  expect_error(AUDPC_2_points(y0 = 0.1, yT = 0.9), "Missing 'time' value")
+test_that("AUDPC_2_points errors with missing `time`", {
+  expect_error(AUDPC_2_points(y0 = 0.1, yT = 0.9), "All parameters")
 })
 
-test_that("AUDCP_2_points errors with missing `y0`", {
-  expect_error(AUDPC_2_points(time = 10, yT = 0.9), "Missing 'y0' value")
+test_that("AUDPC_2_points errors with missing `y0`", {
+  expect_error(AUDPC_2_points(time = 10, yT = 0.9), "All parameters")
 })
 
-test_that("AUDCP_2_points errors with missing `yT`", {
-  expect_error(AUDPC_2_points(time = 10, y0 = 0.1), "Missing 'yT' value")
+test_that("AUDPC_2_points errors with missing `yT`", {
+  expect_error(AUDPC_2_points(time = 10, y0 = 0.1), "All parameters")
 })
 
-test_that("AUDCP_2_points errors when y0 < 0", {
+test_that("AUDPC_2_points errors when y0 < 0", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = -0.1, yT = 0.9),
-    "y0 and yT must be between 0 and <=1 and must not be equal"
+    "strictly between 0 and 1"
   )
 })
 
-test_that("AUDCP_2_points errors when y0 > 1", {
+test_that("AUDPC_2_points errors when y0 > 1", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 1.1, yT = 0.9),
-    "y0 and yT must be between 0 and <=1 and must not be equal"
+    "strictly between 0 and 1"
   )
 })
 
-test_that("AUDCP_2_points errors when yT > 1", {
+test_that("AUDPC_2_points errors when yT > 1", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 0.1, yT = 1.1),
-    "y0 and yT must be between 0 and <=1 and must not be equal"
+    "strictly between 0 and 1"
   )
 })
 
-test_that("AUDCP_2_points errors when y0 == yT", {
+test_that("AUDPC_2_points errors when y0 == 0", {
+  expect_error(
+    AUDPC_2_points(time = 10, y0 = 0, yT = 0.9),
+    "strictly between 0 and 1"
+  )
+})
+
+test_that("AUDPC_2_points errors when yT == 1", {
+  expect_error(
+    AUDPC_2_points(time = 10, y0 = 0.1, yT = 1),
+    "strictly between 0 and 1"
+  )
+})
+
+test_that("AUDPC_2_points errors when y0 == yT", {
   expect_error(
     AUDPC_2_points(time = 10, y0 = 0.1, yT = 0.1),
-    "y0 and yT must be between 0 and <=1 and must not be equal."
+    "strictly between 0 and 1"
+  )
+})
+
+test_that("AUDPC_2_points errors when time <= 0", {
+  expect_error(
+    AUDPC_2_points(time = -5, y0 = 0.1, yT = 0.9),
+    "time must be positive"
+  )
+})
+
+test_that("AUDPC_2_points errors with non-numeric inputs", {
+  expect_error(
+    AUDPC_2_points(time = "10", y0 = 0.1, yT = 0.9),
+    "numeric scalar values"
+  )
+})
+
+test_that("AUDPC_2_points errors with vector inputs", {
+  expect_error(
+    AUDPC_2_points(time = c(10, 20), y0 = 0.1, yT = 0.9),
+    "numeric scalar values"
+  )
+})
+
+test_that("AUDPC_2_points errors with NA values", {
+  expect_error(
+    AUDPC_2_points(time = 10, y0 = NA_real_, yT = 0.9)
+  )
+})
+
+test_that("AUDPC_2_points errors with Inf values", {
+  expect_error(
+    AUDPC_2_points(time = Inf, y0 = 0.1, yT = 0.9),
+    "finite"
   )
 })
 


### PR DESCRIPTION
Removes restriction that I should not have had in place where `yT` could not be <`y0`.