### PR TITLE
Refactor AUDPC to fix bug and improve performance

### DIFF
--- a/R/AUDPC.R
+++ b/R/AUDPC.R
@@ -1,45 +1,46 @@
-AUDPC = function(time, y, y_proportion = TRUE, type = "absolute"){
+AUDPC = function(time, y, y_proportion = TRUE, type = "absolute") {
+  
+  # Input validation
   if (missing(y)) {
-    stop(gettextf("Missing 'y' vector"))
+    stop("Missing 'y' vector", call. = FALSE)
   }
-
-  {
-    if (missing(time)) {
-      stop(gettextf("Missing 'time' vector"))
-    }
+  
+  if (missing(time)) {
+    stop("Missing 'time' vector", call. = FALSE)
   }
-  # if (missing(y_proportion)) {
-  #   stop(gettextf("Missing 'y_proportion' argument.  If 'y' is provided as proportion set 'proportion == TRUE', if is provided as percentage set 'proportion == FALSE' "))
-  # }
-
-  if(type == "relative" & y_proportion==TRUE & max(y)>1){
-    stop(gettextf("If 'y_proportion = TRUE', y should be between 0 and 1 (0>y>1).  When using 'type = relative' make sure to set if 'y' is proportion or percentage"))
+  
+  if (length(time) != length(y)) {
+    stop("Number of elements in 'time' and 'y' must agree", call. = FALSE)
   }
-
-
-  if(length(time)!= length(y)){
-    stop(gettextf("Number of elements in 'time' and 'y' must agree"))}
-
-  if(y_proportion == T){
-    ymax = 1
-  }else{
-    ymax = 100
+  
+  if (length(time) < 2L) {
+    stop("At least 2 time points are required", call. = FALSE)
   }
-  audpc1= auc= max_potential=NULL
-  auc = as.numeric(length(y))
-  for(i in 1:(length(y)-1)){
-    auc[i] = ((y[i]+y[i+1])/2)*(time[i+1]-time[i])
-    audpc1 = sum(auc)
+  
+  # Check for valid type argument
+  type <- match.arg(type, choices = c("absolute", "relative"))
+  
+  # Validate y values for relative AUDPC
+  if (type == "relative" && y_proportion && max(y) > 1) {
+    stop(
+      "If 'y_proportion = TRUE', y should be between 0 and 1 (0 <= y <= 1). ",
+      "When using 'type = \"relative\"' make sure to set if 'y' is proportion or percentage",
+      call. = FALSE
+    )
   }
-  max_potential = ymax * (time[length(time)] - time[1])
-
-  if(type =="absolute"){
-    audpc1=audpc1
+  
+  # Set maximum potential based on y_proportion
+  ymax = if (y_proportion) 1 else 100
+  
+  # Vectorized AUDPC
+  n = length(y) - 1L
+  audpc1 = sum(((y[-n] + y[-1L]) / 2L) * diff(time))
+  
+  # Calculate relative AUDPC if requested
+  if (type == "relative") {
+    max_potential = ymax * (time[length(time)] - time[1L])
+    audpc1 = audpc1 / max_potential
   }
-  if(type =="relative"){
-    audpc1 = audpc1/max_potential
-  }
-
+  
   return(audpc1)
-
 }


### PR DESCRIPTION
* Fixes bug in original implementation. The original {epifitter} code has a bug where `auc = as.numeric(length(y))` creates a `scalar`, not a `vector`, *e.g.*, `auc = as.numeric(length(y))` creates a scalar with the value of `length(y)` (which is 7), not a `vector` of length 7
* Improves performance by using vectorisation over a for loop.
* Adds better user input checks.